### PR TITLE
Update Lesson_3_Let_Users_Mint_Your_NFT.md

### DIFF
--- a/JS_DAO/en/Section_2/Lesson_3_Let_Users_Mint_Your_NFT.md
+++ b/JS_DAO/en/Section_2/Lesson_3_Let_Users_Mint_Your_NFT.md
@@ -136,35 +136,35 @@ const App = () => {
       </div>
     );
   }
-
-  const mintNft = () => {
-    setIsClaiming(true);
-    // Call bundleDropModule.claim("0", 1) to mint nft to user's wallet.
-    bundleDropModule
-    .claim("0", 1)
-    .catch((err) => {
-      console.error("failed to claim", err);
-      setIsClaiming(false);
-    })
-    .finally(() => {
-      // Stop loading state.
-      setIsClaiming(false);
-      // Set claim state.
-      setHasClaimedNFT(true);
-      // Show user their fancy new NFT!
-      console.log(
-        `🌊 Successfully Minted! Check it out on OpenSea: https://testnets.opensea.io/assets/${bundleDropModule.address}/0`
-      );
-    });
-  }
-
+    
+    
   // Render mint nft screen.
   return (
     <div className="mint-nft">
       <h1>Mint your free 🍪DAO Membership NFT</h1>
       <button
         disabled={isClaiming}
-        onClick={() => mintNft()}
+        onClick={() => 
+          setIsClaiming(true);
+          // Call bundleDropModule.claim("0", 1) to mint nft to user's wallet.
+          bundleDropModule
+          .claim("0", 1)
+          .then(() => {
+            // Set claim state.
+            setHasClaimedNFT(true);
+              // Show user their fancy new NFT!
+            console.log(
+                `Successfully Minted! Check it our on OpenSea: https://testnets.opensea.io/assets/${bundleDropModule.address}/0`
+              );
+            })
+          .catch((err) => {
+            console.error("failed to claim", err);
+            })
+          .finally(() => {
+            // Stop loading state.
+            setIsClaiming(false);
+            });
+        }}
       >
         {isClaiming ? "Minting..." : "Mint your nft (FREE)"}
       </button>


### PR DESCRIPTION
Proposed change to reflect fix to a bug in the code for the "Mint an NFT" button. The bug was allowing users to pass to the member page even if they rejected the NFT mint.  This change is from pull request by another user (#mintNFT Bugfix #2), however, there is a syntax error in that PR -- a ";'" immediately before .catch((err) -- that prevented replit from compiling. My change to that code removes the ";"

<img width="574" alt="Screen Shot 2021-12-21 at 4 54 35 PM" src="https://user-images.githubusercontent.com/22897756/147008093-7a074ed7-ab30-4c31-9865-e5637720f2d2.png">
.